### PR TITLE
fix(pdf): add automatic fallback mechanism for failed image embedding

### DIFF
--- a/src/lib/pdf/processors/image-to-pdf.ts
+++ b/src/lib/pdf/processors/image-to-pdf.ts
@@ -248,12 +248,18 @@ export class ImageToPDFProcessor extends BasePDFProcessor {
     const fileType = file.type.toLowerCase();
     const ext = file.name.split('.').pop()?.toLowerCase() || '';
 
-    if (fileType === 'image/jpeg' || ext === 'jpg' || ext === 'jpeg') {
-      image = await pdfDoc.embedJpg(uint8Array);
-    } else if (fileType === 'image/png' || ext === 'png') {
-      image = await pdfDoc.embedPng(uint8Array);
-    } else {
-      // For other formats (including SVG), convert to PNG via canvas
+    try {
+      if (fileType === 'image/jpeg' || ext === 'jpg' || ext === 'jpeg') {
+        image = await pdfDoc.embedJpg(uint8Array);
+      } else if (fileType === 'image/png' || ext === 'png') {
+        image = await pdfDoc.embedPng(uint8Array);
+      } else {
+        throw new Error('Format requires conversion');
+      }
+    } catch (error) {
+      // Fallback: convert to PNG via canvas
+      // This handles cases where extension doesn't match content (e.g. jpg renamed to png)
+      // or formats not natively supported by pdf-lib
       const isSvg = fileType === 'image/svg+xml' || ext === 'svg';
       image = await this.convertAndEmbedImage(pdfDoc, file, pdfLib, isSvg ? options.svgScale : 1);
     }


### PR DESCRIPTION
When pdf-lib fails to embed JPG or PNG images natively (e.g., due to mismatched file extensions and actual content), exceptions are caught via try-catch, and the system automatically falls back to Canvas conversion mode for processing, thereby improving the compatibility of image-to-PDF conversion.