### PR TITLE
fix: file content swapping when compressing multiple PDFs concurrently

### DIFF
--- a/src/lib/pdf/pymupdf-loader.ts
+++ b/src/lib/pdf/pymupdf-loader.ts
@@ -968,14 +968,18 @@ base64.b64encode(pdf_bytes).decode('ascii')
           };
           const settings = qualitySettings[quality] || qualitySettings['medium'];
 
-          pyodide.FS.writeFile('/input.pdf', pdfData);
+          // Use unique file names to avoid race conditions during concurrent processing
+          const uid = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+          const inputPath = `/input_compress_${uid}.pdf`;
+
+          pyodide.FS.writeFile(inputPath, pdfData);
 
           const result = await pyodide.runPythonAsync(`
 import pymupdf
 import base64
 import io
 
-doc = pymupdf.open("/input.pdf")
+doc = pymupdf.open("${inputPath}")
 image_quality = ${settings.imageQuality}
 max_dpi = ${settings.maxDpi}
 remove_metadata = ${removeMetadata ? 'True' : 'False'}
@@ -1072,7 +1076,7 @@ base64.b64encode(pdf_bytes).decode('ascii')
 `);
 
           try {
-            pyodide.FS.unlink('/input.pdf');
+            pyodide.FS.unlink(inputPath);
           } catch {
             // Ignore cleanup errors
           }
@@ -1091,13 +1095,17 @@ base64.b64encode(pdf_bytes).decode('ascii')
           const pdfData = new Uint8Array(arrayBuffer);
           const { dpi = 150, format = 'jpeg', quality = 85 } = options || {};
 
-          pyodide.FS.writeFile('/input.pdf', pdfData);
+          // Use unique file names to avoid race conditions during concurrent processing
+          const uid = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+          const inputPath = `/input_photon_${uid}.pdf`;
+
+          pyodide.FS.writeFile(inputPath, pdfData);
 
           const result = await pyodide.runPythonAsync(`
 import pymupdf
 import base64
 
-doc = pymupdf.open("/input.pdf")
+doc = pymupdf.open("${inputPath}")
 
 # Create a new document
 new_doc = pymupdf.open()
@@ -1138,7 +1146,7 @@ base64.b64encode(pdf_bytes).decode('ascii')
 `);
 
           try {
-            pyodide.FS.unlink('/input.pdf');
+            pyodide.FS.unlink(inputPath);
           } catch {
             // Ignore cleanup errors
           }


### PR DESCRIPTION
Closes #57 

### Summary

- `compress()` and `photonCompress()` in `pymupdf-loader.ts` both wrote to a hardcoded `/input.pdf` path in Pyodide's shared virtual filesystem
- When batch processing 2+ files concurrently, file B would overwrite `/input.pdf` before file A finished reading it, causing output contents to get swapped or duplicated across files
- Fixed by generating a unique file path per operation using a timestamp + random suffix (same pattern already used in `pdfToPdfa()`)

### Root Cause

All concurrent compression jobs shared a single Pyodide WASM instance with one virtual filesystem. The hardcoded `/input.pdf` path meant concurrent writes would race:

```
File A writes /input.pdf → starts processing (slow)
File B writes /input.pdf → overwrites A's data
File A reads /input.pdf  → gets B's content
```

### Test plan

- [x] Compress 3+ distinct PDFs simultaneously using Photon algorithm
- [x] Verify each output file contains its own original content (not duplicated/swapped)

Before change, 1.pdf and 2.pdf file size matches (1 got duplicated to 2):
<img width="1216" height="261" alt="image" src="https://github.com/user-attachments/assets/bbff0bcd-fd19-4b61-9da2-a18a75413bbf" />

After change file size differs:
<img width="1228" height="279" alt="image" src="https://github.com/user-attachments/assets/98791d0e-704a-48f9-8692-caf4bce94962" />


- [x] Verify single-file compression still works
- [x] Verify both ZIP download and individual downloads produce correct results


---
_btw Claude code with Opus 4.6 Max reasoning was able to find and fix the bug in 10 minutes._