### PR TITLE
Add light/dark mode toggle to Header 

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,19 @@ export default function RootLayout({
       <head>
         <meta name="color-scheme" content="light dark" />
         <style dangerouslySetInnerHTML={{ __html: 'html{scrollbar-gutter:stable}' }} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              try {
+                if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                  document.documentElement.classList.add('dark')
+                } else {
+                  document.documentElement.classList.remove('dark')
+                }
+              } catch (_) {}
+            `,
+          }}
+        />
       </head>
       <body className="min-h-screen bg-background text-foreground antialiased">
         {children}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -174,7 +174,7 @@ export const Header: React.FC<HeaderProps> = ({ locale, showSearch = true }) => 
       <div className="container mx-auto px-4">
         <div className="flex h-20 items-center justify-between">
           {/* Logo and Brand */}
-          <div className="flex items-center gap-2">
+          <div className="flex flex-1 items-center gap-2">
             <Link
               href={`/${locale}`}
               className="group flex items-center gap-2.5 text-xl font-bold text-[hsl(var(--color-foreground))] hover:opacity-90 transition-opacity"
@@ -219,7 +219,7 @@ export const Header: React.FC<HeaderProps> = ({ locale, showSearch = true }) => 
           </nav>
 
           {/* Right side actions */}
-          <div className="flex items-center gap-3">
+          <div className="flex flex-1 items-center justify-end gap-3">
             {/* Search */}
             {showSearch && (
               <div className="relative" ref={searchContainerRef}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ import { RecentFilesDropdown } from '@/components/common/RecentFilesDropdown';
 import { searchTools, SearchResult } from '@/lib/utils/search';
 import { getToolContent } from '@/config/tool-content';
 import { getAllTools } from '@/config/tools';
+import { ThemeToggle } from '@/components/ui/ThemeToggle';
 
 export interface HeaderProps {
   locale: Locale;
@@ -325,6 +326,9 @@ export const Header: React.FC<HeaderProps> = ({ locale, showSearch = true }) => 
             >
               <Github className="h-5 w-5" aria-hidden="true" />
             </a>
+
+            {/* Theme Toggle */}
+            <ThemeToggle />
 
             {/* Language Selector placeholder */}
             <div id="language-selector-slot" />

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark' | null>(null);
+
+  useEffect(() => {
+    // Check initial state injected by script
+    const isDark = document.documentElement.classList.contains('dark');
+    setTheme(isDark ? 'dark' : 'light');
+  }, []);
+
+  const toggleTheme = () => {
+    if (theme === 'light') {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+      setTheme('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+      setTheme('light');
+    }
+  };
+
+  // Render placeholder before hydrated to avoid mismatch
+  if (!theme) {
+    return <div className="h-9 w-9" aria-hidden="true" />;
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex items-center justify-center h-9 w-9 rounded-lg text-[hsl(var(--color-muted-foreground))] hover:text-[hsl(var(--color-foreground))] hover:bg-[hsl(var(--color-muted))/0.5] transition-all"
+      aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {theme === 'dark' ? (
+        <Sun className="h-5 w-5" aria-hidden="true" />
+      ) : (
+        <Moon className="h-5 w-5" aria-hidden="true" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
### Changes Included

**Theme Toggle Addition:** Created a new lightweight `ThemeToggle` component (`src/components/ui/ThemeToggle.tsx`) utilizing `lucide-react` icons (Sun/Moon).

**Header Integration:** Integrated the new theme toggle component into the right-side actions group in `src/components/layout/Header.tsx`.

**FOUC Prevention:** Added a synchronous initialization script to the document `<head>` in `src/app/layout.tsx` to detect user preference or stored state on load, preventing any Flash of Unstyled Content. 