### PR TITLE
optimize docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY . .
 
 # Build the static export
 # Use BuildKit cache mount for Next.js cache to speed up rebuilds
+ENV DOCKER_BUILD=true
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=cache,target=/app/.next/cache \
     npm run build
@@ -46,16 +47,6 @@ COPY security-headers.conf /etc/nginx/security-headers.conf
 
 # Copy the static export from builder stage
 COPY --from=builder /app/out /website/pdfcraft
-
-# Decompress LibreOffice WASM .gz files so both original and .gz exist.
-# gzip_static requires the original file to exist; without it, Nginx returns 404.
-# The .gz files are kept alongside for gzip_static to serve to gzip-capable clients.
-RUN if [ -d /website/pdfcraft/libreoffice-wasm ]; then \
-    cd /website/pdfcraft/libreoffice-wasm && \
-    for f in *.gz; do \
-    [ -f "$f" ] && gunzip -k "$f" || true; \
-    done; \
-    fi
 
 # Expose port 80
 EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -105,7 +105,7 @@ server {
     # LibreOffice WASM Files
     # ==========================================
     location ^~ /libreoffice-wasm/ {
-        gzip_static on;
+        gzip_static always;
         expires 1y;
         add_header Cache-Control "public, max-age=31536000, immutable";
         types {

--- a/scripts/chunk-assets.mjs
+++ b/scripts/chunk-assets.mjs
@@ -64,6 +64,11 @@ function walkDir(dir, callback) {
 }
 
 async function main() {
+    if (process.env.DOCKER_BUILD === 'true') {
+        console.log('[chunking] DOCKER_BUILD detected, skipping chunking.');
+        return;
+    }
+
     if (!existsSync(OUT_DIR)) {
         console.log('[chunking] Output directory (out/) not found, skipping.');
         return;

--- a/scripts/decompress-wasm.mjs
+++ b/scripts/decompress-wasm.mjs
@@ -28,6 +28,11 @@ async function decompressFile(gzPath, outPath) {
 }
 
 async function main() {
+    if (process.env.DOCKER_BUILD === 'true') {
+        console.log('[postbuild] DOCKER_BUILD detected, skipping decompression.');
+        return;
+    }
+
     if (!existsSync(WASM_DIR)) {
         console.log('[postbuild] No libreoffice-wasm directory found in out/, skipping.');
         return;


### PR DESCRIPTION
Skipped redundant WASM decompression scripts and leveraged Nginx gzip_static to serve compressed assets directly, reducing the Docker image size from 881MB to 645MB.