### PR TITLE
fix/sign-pdf-viewer-and-save and committed the Sign PDF work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,14 @@ node_modules
 .pnp
 .pnp.js
 
+# Generated .js copies of PDF.js .mjs bundles (see scripts/ensure-pdfjs-viewer-js.js)
+public/pdfjs-viewer/pdf.js
+public/pdfjs-viewer/pdf.worker.js
+public/pdfjs-viewer/pdf.sandbox.js
+public/pdfjs-viewer/pdf_viewer.js
+public/pdfjs-viewer/viewer.js
+public/workers/pdf.worker.min.js
+
 # Build output
 .next
 out

--- a/next.config.js
+++ b/next.config.js
@@ -174,6 +174,20 @@ const nextConfig = {
         ],
       },
       {
+        // MJS files (ES modules) - correct MIME for module scripts
+        source: '/:path*.mjs',
+        headers: [
+          {
+            key: 'Content-Type',
+            value: 'application/javascript; charset=utf-8',
+          },
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
         // HTML pages - short cache with revalidation
         source: '/:path*',
         headers: [

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "postbuild": "node scripts/decompress-wasm.mjs && node scripts/chunk-assets.mjs",
-    "postinstall": "node scripts/sync-pdfjs-workers.js"
+    "predev": "node scripts/ensure-pdfjs-viewer-js.js public",
+    "postinstall": "node scripts/sync-pdfjs-workers.js && node scripts/ensure-pdfjs-viewer-js.js public",
+    "postbuild": "node scripts/decompress-wasm.mjs && node scripts/chunk-assets.mjs && node scripts/ensure-pdfjs-viewer-js.js out"
   },
   "dependencies": {
     "@matbee/libreoffice-converter": "^2.5.0",

--- a/public/pdfjs-viewer/form-viewer.html
+++ b/public/pdfjs-viewer/form-viewer.html
@@ -167,10 +167,10 @@
   </div>
 
   <script type="module">
-    import * as pdfjsLib from './pdf.mjs';
-    import { EventBus, PDFViewer, PDFLinkService, PDFScriptingManager } from './pdf_viewer.mjs';
+    import * as pdfjsLib from './pdf.js';
+    import { EventBus, PDFViewer, PDFLinkService, PDFScriptingManager } from './pdf_viewer.js';
 
-    pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.mjs';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.js';
 
     const eventBus = new EventBus();
     const linkService = new PDFLinkService({ eventBus });
@@ -179,7 +179,7 @@
     const scriptingManager = new PDFScriptingManager({
       eventBus,
       // Use the packaged sandbox for PDF.js JavaScript (required for XFA)
-      sandboxBundleSrc: './pdf.sandbox.mjs',
+      sandboxBundleSrc: './pdf.sandbox.js',
       docProperties: async (pdfDocument) => {
         // Minimal doc properties are fine; XFA scripts mostly need field objects
         return {

--- a/public/pdfjs-viewer/sign-viewer.html
+++ b/public/pdfjs-viewer/sign-viewer.html
@@ -194,10 +194,10 @@
   </div>
 
   <script type="module">
-    import * as pdfjsLib from './pdf.mjs';
-    import { EventBus, PDFViewer, PDFLinkService } from './pdf_viewer.mjs';
+    import * as pdfjsLib from './pdf.js';
+    import { EventBus, PDFViewer, PDFLinkService } from './pdf_viewer.js';
 
-    pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.mjs';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.js';
 
     const eventBus = new EventBus();
     const linkService = new PDFLinkService({ eventBus });

--- a/public/pdfjs-viewer/viewer.html
+++ b/public/pdfjs-viewer/viewer.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <!--
 Copyright 2012 Mozilla Foundation
 
@@ -29,11 +29,11 @@ See https://github.com/adobe-type-tools/cmap-resources
 
 <!-- This snippet is used in production (included from viewer.html) -->
 <link rel="resource" type="application/l10n" href="locale/locale.json">
-<script src="pdf.mjs" type="module"></script>
+<script src="pdf.js" type="module"></script>
 
     <link rel="stylesheet" href="viewer.css">
 
-  <script src="viewer.mjs" type="module"></script>
+  <script src="viewer.js" type="module"></script>
   </head>
 
   <body tabindex="0">

--- a/scripts/ensure-pdfjs-viewer-js.js
+++ b/scripts/ensure-pdfjs-viewer-js.js
@@ -1,0 +1,70 @@
+/**
+ * Generate .js copies of PDF.js viewer .mjs bundles so hosts that serve
+ * unknown extensions as application/octet-stream still load the viewer.
+ *
+ * Usage:
+ *   node scripts/ensure-pdfjs-viewer-js.js [public|out]
+ */
+
+import { copyFileSync, existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+
+const target = process.argv[2] || 'public';
+const viewerDir = join(rootDir, target, 'pdfjs-viewer');
+const workersDir = join(rootDir, target, 'workers');
+
+function convertMjsToJs(dir) {
+  if (!existsSync(dir)) {
+    console.log(`[ensure-pdfjs-js] Skip: ${dir} not found`);
+    return;
+  }
+
+  const mjsFiles = readdirSync(dir).filter((name) => name.endsWith('.mjs'));
+  for (const mjsFile of mjsFiles) {
+    const mjsPath = join(dir, mjsFile);
+    const jsPath = join(dir, mjsFile.replace(/\.mjs$/, '.js'));
+    let content = readFileSync(mjsPath, 'utf8');
+    content = content.replace(/\.mjs/g, '.js');
+    writeFileSync(jsPath, content);
+    console.log(`[ensure-pdfjs-js] ${target}/${mjsFile} -> ${mjsFile.replace(/\.mjs$/, '.js')}`);
+  }
+}
+
+function patchHtmlFiles(dir) {
+  if (!existsSync(dir)) return;
+
+  for (const htmlFile of ['viewer.html', 'form-viewer.html', 'sign-viewer.html']) {
+    const htmlPath = join(dir, htmlFile);
+    if (!existsSync(htmlPath)) continue;
+
+    const html = readFileSync(htmlPath, 'utf8');
+    const patched = html.replace(/\.mjs/g, '.js');
+    if (patched !== html) {
+      writeFileSync(htmlPath, patched);
+      console.log(`[ensure-pdfjs-js] Patched ${target}/pdfjs-viewer/${htmlFile}`);
+    }
+  }
+}
+
+function copyDeploymentFiles() {
+  if (target !== 'out') return;
+
+  const htaccessSrc = join(rootDir, '.htaccess');
+  const htaccessDest = join(rootDir, 'out', '.htaccess');
+  if (existsSync(htaccessSrc)) {
+    copyFileSync(htaccessSrc, htaccessDest);
+    console.log('[ensure-pdfjs-js] Copied .htaccess to out/');
+  }
+}
+
+convertMjsToJs(viewerDir);
+patchHtmlFiles(viewerDir);
+convertMjsToJs(workersDir);
+copyDeploymentFiles();
+
+console.log('[ensure-pdfjs-js] Done.');

--- a/scripts/sync-pdfjs-workers.js
+++ b/scripts/sync-pdfjs-workers.js
@@ -52,7 +52,15 @@ for (const worker of workerFiles) {
         copyFileSync(srcPath, destPath);
         console.log(`✓ Copied ${worker.name}`);
         console.log(`  From: ${worker.src}`);
-        console.log(`  To:   ${worker.dest}\n`);
+        console.log(`  To:   ${worker.dest}`);
+
+        // Also create a .js copy for hosts that serve .mjs as application/octet-stream
+        if (destPath.endsWith('.mjs')) {
+            const jsDestPath = destPath.replace(/\.mjs$/, '.js');
+            copyFileSync(srcPath, jsDestPath);
+            console.log(`  To:   ${jsDestPath.replace(rootDir + '/', '')}`);
+        }
+        console.log('');
     } catch (error) {
         console.error(`✗ Failed to copy ${worker.name}:`, error.message);
     }

--- a/src/components/tools/sign/SignPDFTool.tsx
+++ b/src/components/tools/sign/SignPDFTool.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { FileUploader } from '../FileUploader';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
-import { PDFDocument } from 'pdf-lib';
+import { withBasePath } from '@/lib/utils/path';
 
 export interface SignPDFToolProps {
   className?: string;
@@ -13,14 +13,40 @@ export interface SignPDFToolProps {
 
 interface SignState {
   file: File | null;
-  blobUrl: string | null;
   viewerReady: boolean;
 }
+
+type PdfViewerWindow = Window & {
+  PDFViewerApplication?: {
+    initializedPromise: Promise<void>;
+    open: (args: { data: Uint8Array }) => Promise<void>;
+    pdfDocument?: {
+      annotationStorage: { size: number };
+      saveDocument: () => Promise<Uint8Array | ArrayBuffer>;
+    };
+    pdfViewer?: {
+      annotationEditorUIManager?: { commitOrRemove: () => void };
+      annotationEditorMode: { mode: number };
+    };
+    eventBus?: {
+      _on: (
+        event: string,
+        listener: () => void,
+        options?: { once?: boolean }
+      ) => void;
+    };
+  };
+  pdfjsLib?: {
+    AnnotationEditorType?: { NONE: number };
+  };
+};
+
+const VIEWER_HTML = withBasePath('/pdfjs-viewer/viewer.html');
 
 /**
  * SignPDFTool Component
  * Uses PDF.js viewer with native signature editor for comprehensive signing support.
- * Supports: draw (handwritten), type (text), and image signatures.
+ * Supports: draw (handwritten), type, and image signatures.
  */
 export function SignPDFTool({ className = '' }: SignPDFToolProps) {
   const t = useTranslations('common');
@@ -28,23 +54,13 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
 
   const [signState, setSignState] = useState<SignState>({
     file: null,
-    blobUrl: null,
     viewerReady: false,
   });
   const [error, setError] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [flattenSignature, setFlattenSignature] = useState(true);
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
-
-  // Cleanup blob URL on unmount or file change
-  useEffect(() => {
-    return () => {
-      if (signState.blobUrl) {
-        URL.revokeObjectURL(signState.blobUrl);
-      }
-    };
-  }, [signState.blobUrl]);
+  const fileRef = useRef<File | null>(null);
 
   /**
    * Handle file selected
@@ -52,14 +68,7 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
   const handleFilesSelected = useCallback((files: File[]) => {
     if (files.length > 0) {
       const file = files[0];
-
-      // Cleanup previous blob URL
-      if (signState.blobUrl) {
-        URL.revokeObjectURL(signState.blobUrl);
-      }
-
-      // Create new blob URL
-      const blobUrl = URL.createObjectURL(file);
+      fileRef.current = file;
 
       // Configure PDF.js preferences for signature editor
       try {
@@ -78,12 +87,11 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
 
       setSignState({
         file,
-        blobUrl,
         viewerReady: false,
       });
       setError(null);
     }
-  }, [signState.blobUrl]);
+  }, []);
 
   /**
    * Handle file upload error
@@ -93,51 +101,79 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
   }, []);
 
   /**
-   * Handle iframe load
+   * Enable signature tools in the viewer UI
    */
-  const handleIframeLoad = useCallback(() => {
-    setSignState(prev => ({ ...prev, viewerReady: true }));
+  const enableSignatureTools = useCallback((viewerWindow: PdfViewerWindow) => {
+    const app = viewerWindow.PDFViewerApplication;
+    if (!app?.eventBus) return;
 
-    // Try to enable signature tools
-    try {
-      const iframe = iframeRef.current;
-      if (!iframe?.contentWindow) return;
+    const doc = viewerWindow.document;
+    const { eventBus } = app;
 
-      const viewerWindow = iframe.contentWindow as any;
-      if (viewerWindow?.PDFViewerApplication) {
-        const app = viewerWindow.PDFViewerApplication;
-        const doc = viewerWindow.document;
-        const eventBus = app.eventBus;
+    const enable = () => {
+      const editorModeButtons = doc.getElementById('editorModeButtons');
+      editorModeButtons?.classList.remove('hidden');
 
-        eventBus?._on('annotationeditoruimanager', () => {
-          // Show signature editor buttons
-          const editorModeButtons = doc.getElementById('editorModeButtons');
-          editorModeButtons?.classList.remove('hidden');
+      const editorSignature = doc.getElementById('editorSignature');
+      editorSignature?.removeAttribute('hidden');
 
-          const editorSignature = doc.getElementById('editorSignature');
-          editorSignature?.removeAttribute('hidden');
-
-          const editorSignatureButton = doc.getElementById('editorSignatureButton') as HTMLButtonElement | null;
-          if (editorSignatureButton) {
-            editorSignatureButton.disabled = false;
-          }
-
-          const editorStamp = doc.getElementById('editorStamp');
-          editorStamp?.removeAttribute('hidden');
-
-          const editorStampButton = doc.getElementById('editorStampButton') as HTMLButtonElement | null;
-          if (editorStampButton) {
-            editorStampButton.disabled = false;
-          }
-        });
+      const editorSignatureButton = doc.getElementById('editorSignatureButton') as HTMLButtonElement | null;
+      if (editorSignatureButton) {
+        editorSignatureButton.disabled = false;
       }
-    } catch (e) {
-      console.error('Could not initialize PDF.js viewer:', e);
-    }
+
+      const editorStamp = doc.getElementById('editorStamp');
+      editorStamp?.removeAttribute('hidden');
+
+      const editorStampButton = doc.getElementById('editorStampButton') as HTMLButtonElement | null;
+      if (editorStampButton) {
+        editorStampButton.disabled = false;
+      }
+    };
+
+    eventBus._on('annotationeditoruimanager', enable);
+    enable();
   }, []);
 
   /**
-   * Save signed PDF
+   * Load PDF into viewer via ArrayBuffer (avoids blob: URL issues on HTTP)
+   */
+  const handleIframeLoad = useCallback(async () => {
+    const file = fileRef.current;
+    const iframe = iframeRef.current;
+    if (!file || !iframe?.contentWindow) return;
+
+    try {
+      const viewerWindow = iframe.contentWindow as PdfViewerWindow;
+      const app = viewerWindow.PDFViewerApplication;
+      if (!app) return;
+
+      await app.initializedPromise;
+
+      let documentLoaded = false;
+      const onDocumentLoaded = () => {
+        if (documentLoaded) return;
+        documentLoaded = true;
+        setSignState(prev => ({ ...prev, viewerReady: true }));
+        enableSignatureTools(viewerWindow);
+      };
+
+      app.eventBus?._on('documentloaded', onDocumentLoaded, { once: true });
+
+      const pdfData = new Uint8Array(await file.arrayBuffer());
+      await app.open({ data: pdfData });
+
+      if (!documentLoaded && app.pdfDocument) {
+        onDocumentLoaded();
+      }
+    } catch (e) {
+      console.error('Could not load PDF in viewer:', e);
+      setError('Failed to load PDF in the viewer. Please try again.');
+    }
+  }, [enableSignatureTools]);
+
+  /**
+   * Save signed PDF using PDF.js native save (embeds signatures into the file)
    */
   const handleSave = useCallback(async () => {
     if (!signState.viewerReady || !iframeRef.current) {
@@ -147,71 +183,71 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
 
     try {
       setIsProcessing(true);
-      const viewerWindow = iframeRef.current.contentWindow as any;
+      setError(null);
 
-      if (!viewerWindow?.PDFViewerApplication) {
+      const viewerWindow = iframeRef.current.contentWindow as PdfViewerWindow;
+      const app = viewerWindow.PDFViewerApplication;
+
+      if (!app?.pdfDocument) {
         setError('PDF viewer not initialized.');
         setIsProcessing(false);
         return;
       }
 
-      const app = viewerWindow.PDFViewerApplication;
+      const { pdfDocument, pdfViewer } = app;
 
-      if (flattenSignature) {
-        // Flatten and save
-        const rawPdfBytes = await app.pdfDocument.saveDocument(app.pdfDocument.annotationStorage);
-        const pdfBytes = new Uint8Array(rawPdfBytes);
-        const pdfDoc = await PDFDocument.load(pdfBytes);
-
-        try {
-          pdfDoc.getForm().flatten();
-        } catch (e) {
-          // Form might not exist, continue
-        }
-
-        const flattenedPdfBytes = await pdfDoc.save();
-        const blob = new Blob([new Uint8Array(flattenedPdfBytes).buffer as ArrayBuffer], { type: 'application/pdf' });
-
-        // Download
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `signed_${signState.file?.name || 'document.pdf'}`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
-      } else {
-        // Use PDF.js native download
-        app.eventBus?.dispatch('download', { source: app });
+      // Commit any signature still being placed/edited
+      pdfViewer?.annotationEditorUIManager?.commitOrRemove();
+      // Exit editor mode (PDF.js expects { mode }, not a raw number; DISABLE is invalid here)
+      if (pdfViewer) {
+        const editorNone =
+          viewerWindow.pdfjsLib?.AnnotationEditorType?.NONE ?? 0;
+        pdfViewer.annotationEditorMode = { mode: editorNone };
       }
 
+      if (pdfDocument.annotationStorage.size === 0) {
+        setError(
+          'No signature found. Add a signature using the pen tool in the toolbar, then try again.'
+        );
+        setIsProcessing(false);
+        return;
+      }
+
+      const rawPdfBytes = await pdfDocument.saveDocument();
+      const pdfBytes = Uint8Array.from(
+        rawPdfBytes instanceof Uint8Array ? rawPdfBytes : new Uint8Array(rawPdfBytes)
+      );
+
+      const blob = new Blob([pdfBytes.buffer], { type: 'application/pdf' });
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `signed_${signState.file?.name || 'document.pdf'}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
       setIsProcessing(false);
-    } catch (error) {
-      console.error('Failed to save signed PDF:', error);
+    } catch (err) {
+      console.error('Failed to save signed PDF:', err);
       setError('Failed to save signed PDF. Please try again.');
       setIsProcessing(false);
     }
-  }, [signState.viewerReady, signState.file, flattenSignature]);
+  }, [signState.viewerReady, signState.file]);
 
   /**
    * Clear and start over
    */
   const handleClear = useCallback(() => {
-    if (signState.blobUrl) {
-      URL.revokeObjectURL(signState.blobUrl);
-    }
+    fileRef.current = null;
     setSignState({
       file: null,
-      blobUrl: null,
       viewerReady: false,
     });
     setError(null);
-  }, [signState.blobUrl]);
-
-  const viewerUrl = signState.blobUrl
-    ? `/pdfjs-viewer/viewer.html?file=${encodeURIComponent(signState.blobUrl)}`
-    : null;
+  }, []);
 
   return (
     <div className={`space-y-6 ${className}`.trim()}>
@@ -240,7 +276,7 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
       )}
 
       {/* PDF Viewer */}
-      {signState.file && viewerUrl && (
+      {signState.file && (
         <>
           {/* File Info & Clear Button */}
           <Card variant="outlined">
@@ -291,8 +327,9 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
           {/* PDF.js Viewer Iframe */}
           <div className="border border-[hsl(var(--color-border))] rounded-[var(--radius-lg)] overflow-hidden">
             <iframe
+              key={signState.file.name + signState.file.lastModified}
               ref={iframeRef}
-              src={viewerUrl}
+              src={VIEWER_HTML}
               onLoad={handleIframeLoad}
               className="w-full bg-gray-100"
               style={{ height: '600px', border: 'none' }}
@@ -300,36 +337,21 @@ export function SignPDFTool({ className = '' }: SignPDFToolProps) {
             />
           </div>
 
-          {/* Options and Save Button */}
+          {/* Save Button */}
           <Card variant="outlined">
-            <div className="space-y-4">
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={flattenSignature}
-                  onChange={(e) => setFlattenSignature(e.target.checked)}
-                  disabled={isProcessing}
-                  className="w-4 h-4 rounded border-[hsl(var(--color-border))] text-[hsl(var(--color-primary))] focus:ring-[hsl(var(--color-primary))]"
-                />
-                <span className="text-sm text-[hsl(var(--color-foreground))]">
-                  {tTools('signPdf.flattenOption') || 'Flatten signature (recommended - makes signature permanent)'}
-                </span>
-              </label>
-
-              <div className="flex gap-4">
-                <Button
-                  variant="primary"
-                  size="lg"
-                  onClick={handleSave}
-                  disabled={!signState.viewerReady || isProcessing}
-                  loading={isProcessing}
-                >
-                  {isProcessing
-                    ? (t('status.processing') || 'Processing...')
-                    : (tTools('signPdf.saveButton') || 'Save Signed PDF')
-                  }
-                </Button>
-              </div>
+            <div className="flex gap-4">
+              <Button
+                variant="primary"
+                size="lg"
+                onClick={handleSave}
+                disabled={!signState.viewerReady || isProcessing}
+                loading={isProcessing}
+              >
+                {isProcessing
+                  ? (t('status.processing') || 'Processing...')
+                  : (tTools('signPdf.saveButton') || 'Save Signed PDF')
+                }
+              </Button>
             </div>
           </Card>
         </>

--- a/src/lib/pdf/config.ts
+++ b/src/lib/pdf/config.ts
@@ -6,7 +6,7 @@
  * Libraries are lazy-loaded to optimize initial page load.
  */
 
-/**
+/**The file at 'blob:http://pdfcrafts.test/7e5bc74f-8bb7-4280-8a23-96852ad1356f' was loaded over an insecure connection. This file should be served over HTTPS.
  * PDF.js configuration
  */
 export const PDFJS_CONFIG = {

--- a/src/lib/pdf/loader.ts
+++ b/src/lib/pdf/loader.ts
@@ -34,8 +34,8 @@ export function configurePdfjsWorker(pdfjsLib: PDFJSModule): void {
 
   if (typeof window !== 'undefined') {
     // Use the local worker file for offline support
-    // The worker file is located in public/workers/pdf.worker.min.mjs
-    pdfjsLib.GlobalWorkerOptions.workerSrc = withBasePath('/workers/pdf.worker.min.mjs');
+    // The worker file is located in public/workers/pdf.worker.min.js
+    pdfjsLib.GlobalWorkerOptions.workerSrc = withBasePath('/workers/pdf.worker.min.js');
     workerConfigured = true;
   }
 }

--- a/src/lib/pdf/processors/pdf-to-markdown.ts
+++ b/src/lib/pdf/processors/pdf-to-markdown.ts
@@ -13,10 +13,11 @@ import type {
 } from '@/types/pdf';
 import { PDFErrorCode } from '@/types/pdf';
 import { BasePDFProcessor } from '../processor';
+import { withBasePath } from '@/lib/utils/path';
 
 // Initialize PDF.js worker
 if (typeof window !== 'undefined') {
-    PDFJS.GlobalWorkerOptions.workerSrc = '/workers/pdf.worker.min.mjs';
+    PDFJS.GlobalWorkerOptions.workerSrc = withBasePath('/workers/pdf.worker.min.js');
 }
 
 /**


### PR DESCRIPTION
Fix Sign PDF viewer loading and preserve signatures on save. Serve PDF.js bundles as .js for hosts that mislabel .mjs, load PDFs via ArrayBuffer instead of blob URLs, and save with PDF.js saveDocument so drawn signatures are embedded in the downloaded file.