### PR TITLE
fix(workflow): route uploads to parallel input nodes by file type

### DIFF
--- a/src/__tests__/workflow/engine.test.ts
+++ b/src/__tests__/workflow/engine.test.ts
@@ -14,6 +14,8 @@ import {
     validateConnection,
     validateWorkflow,
     calculateProgress,
+    distributeFilesToInputNodes,
+    fileMatchesAcceptedFormats,
 } from '@/lib/workflow/engine';
 import type { WorkflowNode, WorkflowEdge } from '@/types/workflow';
 
@@ -296,6 +298,65 @@ describe('Workflow Engine', () => {
             ];
             const progress = calculateProgress(mixedNodes);
             expect(progress).toBe(Math.round((100 + 50 + 0) / 3));
+        });
+    });
+
+    describe('fileMatchesAcceptedFormats', () => {
+        it('matches extensions with or without leading dot', () => {
+            expect(fileMatchesAcceptedFormats('photo.PNG', ['.png'])).toBe(true);
+            expect(fileMatchesAcceptedFormats('photo.jpg', ['.jpeg'])).toBe(false);
+            expect(fileMatchesAcceptedFormats('photo.jpeg', ['.jpg', '.jpeg'])).toBe(true);
+        });
+    });
+
+    describe('distributeFilesToInputNodes', () => {
+        const pngNode: WorkflowNode = {
+            id: 'png',
+            type: 'toolNode',
+            position: { x: 0, y: 0 },
+            data: {
+                toolId: 'png-to-pdf',
+                label: 'PNG to PDF',
+                icon: 'image-up',
+                category: 'convert-to-pdf',
+                acceptedFormats: ['.png'],
+                outputFormat: 'pdf',
+                status: 'idle',
+                progress: 0,
+            },
+        };
+
+        const jpgNode: WorkflowNode = {
+            id: 'jpg',
+            type: 'toolNode',
+            position: { x: 200, y: 0 },
+            data: {
+                toolId: 'jpg-to-pdf',
+                label: 'JPG to PDF',
+                icon: 'image-up',
+                category: 'convert-to-pdf',
+                acceptedFormats: ['.jpg', '.jpeg'],
+                outputFormat: 'pdf',
+                status: 'idle',
+                progress: 0,
+            },
+        };
+
+        it('routes each file to the matching input node only', () => {
+            const png = new File([new Blob(['p'])], 'a.png', { type: 'image/png' });
+            const jpg = new File([new Blob(['j'])], 'b.jpg', { type: 'image/jpeg' });
+            const map = distributeFilesToInputNodes([png, jpg], [pngNode, jpgNode]);
+
+            expect(map.get('png')).toEqual([png]);
+            expect(map.get('jpg')).toEqual([jpg]);
+        });
+
+        it('gives all files to a single input node', () => {
+            const png = new File([new Blob(['p'])], 'a.png', { type: 'image/png' });
+            const jpg = new File([new Blob(['j'])], 'b.jpg', { type: 'image/jpeg' });
+            const map = distributeFilesToInputNodes([png, jpg], [pngNode]);
+
+            expect(map.get('png')).toEqual([png, jpg]);
         });
     });
 });

--- a/src/__tests__/workflow/executor.test.ts
+++ b/src/__tests__/workflow/executor.test.ts
@@ -65,6 +65,14 @@ describe('Workflow Executor', () => {
             expect(inputs).toHaveLength(0);
         });
 
+        it('should prefer inputAssignments over stale node.data.inputFiles', () => {
+            const assigned = new File([new Blob(['png'])], 'only.png', { type: 'image/png' });
+            const assignments = new Map<string, File[]>([['node1', [assigned]]]);
+            const inputs = collectInputFiles('node1', nodes, [], new Map(), assignments);
+            expect(inputs).toHaveLength(1);
+            expect((inputs[0] as File).name).toBe('only.png');
+        });
+
         it('should collect outputs from parent nodes', () => {
             const nodeOutputs = new Map<string, (Blob | WorkflowOutputFile)[]>();
             const output1: WorkflowOutputFile = {

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -24,7 +24,7 @@ import 'reactflow/dist/style.css';
 import { useTranslations } from 'next-intl';
 import { logger } from '@/lib/utils/logger';
 import { WorkflowNode, WorkflowEdge, ToolNodeData, WorkflowExecutionState, SavedWorkflow, WorkflowTemplate, WorkflowOutputFile } from '@/types/workflow';
-import { validateWorkflow, validateConnection, topologicalSort, findInputNodes } from '@/lib/workflow/engine';
+import { validateWorkflow, validateConnection, topologicalSort, findInputNodes, distributeFilesToInputNodes } from '@/lib/workflow/engine';
 import { executeNode, collectInputFiles } from '@/lib/workflow/executor';
 import { buildNodeOutputsFromResult, deriveWorkflowFailureContext } from '@/lib/workflow/execution-utils';
 import { saveWorkflow, getSavedWorkflows, deleteWorkflow, duplicateWorkflow, exportWorkflow, importWorkflow } from '@/lib/workflow/storage';
@@ -387,13 +387,14 @@ function WorkflowEditorContent() {
                 `for ${inputNodes.length} input node(s): ${inputNodes.map(n => n.data.label).join(', ')}`
             );
 
-            // Assign input files to all input nodes
-            // Note: All input nodes receive ALL files
+            const inputFileAssignments = distributeFilesToInputNodes(inputFiles, inputNodes);
+
             setNodes((nds) => nds.map(node => {
-                if (inputNodes.some(n => n.id === node.id)) {
+                const assigned = inputFileAssignments.get(node.id);
+                if (assigned !== undefined) {
                     return {
                         ...node,
-                        data: { ...node.data, inputFiles },
+                        data: { ...node.data, inputFiles: assigned },
                     };
                 }
                 return node;
@@ -449,11 +450,19 @@ function WorkflowEditorContent() {
                     nodeId,
                     nodes as WorkflowNode[],
                     edges as WorkflowEdge[],
-                    nodeOutputs
+                    nodeOutputs,
+                    inputFileAssignments
                 );
 
-                // If this is an input node without parent outputs, use the selected files
-                const filesToProcess = nodeInputFiles.length > 0 ? nodeInputFiles : inputFiles;
+                const isInputNode = inputNodes.some((n) => n.id === nodeId);
+                const filesToProcess =
+                    nodeInputFiles.length > 0
+                        ? nodeInputFiles
+                        : isInputNode
+                          ? []
+                          : inputNodes.length === 1
+                            ? inputFiles
+                            : [];
 
                 // Log input sizes for debugging data flow
                 const inputSizes = filesToProcess.map((f, idx) => {

--- a/src/lib/workflow/engine.ts
+++ b/src/lib/workflow/engine.ts
@@ -78,6 +78,68 @@ export function findInputNodes(nodes: WorkflowNode[], edges: WorkflowEdge[]): Wo
 }
 
 /**
+ * Check whether a filename matches one of the node's accepted format extensions.
+ */
+export function fileMatchesAcceptedFormats(filename: string, acceptedFormats: string[]): boolean {
+    if (acceptedFormats.length === 0) return true;
+    const lower = filename.toLowerCase();
+    return acceptedFormats.some((format) => {
+        const ext = format.startsWith('.') ? format.toLowerCase() : `.${format.toLowerCase()}`;
+        return lower.endsWith(ext);
+    });
+}
+
+/**
+ * Assign uploaded files to workflow input nodes by each node's acceptedFormats.
+ * Used when multiple parallel input nodes (e.g. PNG to PDF + JPG to PDF) share one upload.
+ */
+export function distributeFilesToInputNodes(
+    files: File[],
+    inputNodes: WorkflowNode[]
+): Map<string, File[]> {
+    const distribution = new Map<string, File[]>();
+    const claimed = new Set<string>();
+
+    for (const node of inputNodes) {
+        distribution.set(node.id, []);
+    }
+
+    if (inputNodes.length === 0) {
+        return distribution;
+    }
+
+    if (inputNodes.length === 1) {
+        distribution.set(inputNodes[0].id, [...files]);
+        return distribution;
+    }
+
+    for (const node of inputNodes) {
+        const formats = node.data.acceptedFormats ?? [];
+        const matched = files.filter(
+            (f) =>
+                fileMatchesAcceptedFormats(f.name, formats) &&
+                !claimed.has(f.name)
+        );
+        matched.forEach((f) => claimed.add(f.name));
+        distribution.set(node.id, matched);
+    }
+
+    for (const file of files) {
+        if (claimed.has(file.name)) continue;
+        for (const node of inputNodes) {
+            const formats = node.data.acceptedFormats ?? [];
+            if (fileMatchesAcceptedFormats(file.name, formats)) {
+                distribution.get(node.id)!.push(file);
+                claimed.add(file.name);
+                break;
+            }
+        }
+    }
+
+    return distribution;
+}
+
+/**
  * Find output nodes (nodes with no outgoing edges)
  */
 export function findOutputNodes(nodes: WorkflowNode[], edges: WorkflowEdge[]): WorkflowNode[] {
@@ -200,7 +262,7 @@ export function validateWorkflow(
     if (inputNodes.length > 1) {
         const nodeNames = inputNodes.map(n => `"${n.data.label}"`).join(', ');
         warnings.push({
-            message: `Workflow has ${inputNodes.length} input nodes (${nodeNames}). All selected files will be sent to each input node. Each input node will process all files independently before passing results to downstream nodes.`,
+            message: `Workflow has ${inputNodes.length} input nodes (${nodeNames}). Uploaded files are routed to each input node by file type (e.g. .png to PNG to PDF, .jpg to JPG to PDF).`,
         });
     }
 

--- a/src/lib/workflow/executor.ts
+++ b/src/lib/workflow/executor.ts
@@ -9,6 +9,7 @@
  */
 
 import { WorkflowNode, WorkflowEdge, WorkflowOutputFile } from '@/types/workflow';
+import { fileMatchesAcceptedFormats } from '@/lib/workflow/engine';
 import type { ProcessOutput, ProgressCallback, ProcessInput } from '@/types/pdf';
 import { PDFErrorCode, ErrorCategory } from '@/types/pdf';
 import { logger } from '@/lib/utils/logger';
@@ -131,9 +132,14 @@ export async function executeNode(
     const settings = node.data.settings || {};
 
     // Convert all inputs to File objects with proper metadata
-    const files: File[] = inputFiles.map((f, i) => 
+    const allFiles: File[] = inputFiles.map((f, i) =>
         convertToFile(f, i, `workflow_${toolId}`)
     );
+
+    const acceptedFormats = node.data.acceptedFormats ?? [];
+    const files: File[] = acceptedFormats.length > 0
+        ? allFiles.filter((f) => fileMatchesAcceptedFormats(f.name, acceptedFormats))
+        : allFiles;
 
     try {
         switch (toolId) {
@@ -1001,11 +1007,15 @@ export function collectInputFiles(
     nodeId: string,
     nodes: WorkflowNode[],
     edges: WorkflowEdge[],
-    nodeOutputs: Map<string, (Blob | WorkflowOutputFile)[]>
+    nodeOutputs: Map<string, (Blob | WorkflowOutputFile)[]>,
+    inputAssignments?: Map<string, File[]>
 ): (Blob | WorkflowOutputFile)[] {
     const parentEdges = edges.filter(e => e.target === nodeId);
 
     if (parentEdges.length === 0) {
+        if (inputAssignments?.has(nodeId)) {
+            return inputAssignments.get(nodeId)!;
+        }
         const node = nodes.find(n => n.id === nodeId);
         if (node?.data.inputFiles) {
             return node.data.inputFiles;


### PR DESCRIPTION
When PNG/JPG to PDF nodes feed Merge, each converter now receives only matching files instead of the full upload set, so merge outputs one PDF.