### PR TITLE
Fix Word to PDF in workflows when Cross-Origin Isolation is unavailable.

### DIFF
--- a/src/components/tools/word-to-pdf/WordToPDFTool.tsx
+++ b/src/components/tools/word-to-pdf/WordToPDFTool.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { BatchProcessingPanel } from '@/components/common/BatchProcessingPanel';
 import { wordToPDF } from '@/lib/pdf/processors/word-to-pdf';
+import { isCrossOriginIsolated } from '@/lib/utils/cross-origin-isolated';
 import type { UploadedFile, ProcessOutput } from '@/types/pdf';
 
 /**
@@ -47,11 +48,21 @@ export function WordToPDFTool({ className = '' }: WordToPDFToolProps) {
     // Ref for cancellation
     const cancelledRef = useRef(false);
 
-    // Preload LibreOffice WASM when the component mounts
+    // Preload conversion engine when the component mounts
     useEffect(() => {
         let cancelled = false;
         (async () => {
             try {
+                if (!isCrossOriginIsolated()) {
+                    if (cancelled) return;
+                    setPreloadStatus('complete');
+                    setPreloadProgress(100);
+                    setPreloadMessage(
+                        'Compatibility mode: .docx converts without server isolation headers. .doc/.odt/.rtf need COOP/COEP on your host.'
+                    );
+                    return;
+                }
+
                 const { getLibreOfficeConverter } = await import('@/lib/libreoffice');
                 if (cancelled) return;
                 const converter = getLibreOfficeConverter();

--- a/src/components/workflow/WorkflowEditor.tsx
+++ b/src/components/workflow/WorkflowEditor.tsx
@@ -26,6 +26,8 @@ import { logger } from '@/lib/utils/logger';
 import { WorkflowNode, WorkflowEdge, ToolNodeData, WorkflowExecutionState, SavedWorkflow, WorkflowTemplate, WorkflowOutputFile } from '@/types/workflow';
 import { validateWorkflow, validateConnection, topologicalSort, findInputNodes } from '@/lib/workflow/engine';
 import { executeNode, collectInputFiles } from '@/lib/workflow/executor';
+import { LIBREOFFICE_TOOL_IDS, preloadLibreOfficeConverter } from '@/lib/libreoffice/shared-converter';
+import { isCrossOriginIsolated } from '@/lib/utils/cross-origin-isolated';
 import { buildNodeOutputsFromResult, deriveWorkflowFailureContext } from '@/lib/workflow/execution-utils';
 import { saveWorkflow, getSavedWorkflows, deleteWorkflow, duplicateWorkflow, exportWorkflow, importWorkflow } from '@/lib/workflow/storage';
 import { createExecutionRecord, addExecutionRecord, completeExecutionRecord } from '@/lib/workflow/history';
@@ -401,6 +403,20 @@ function WorkflowEditorContent() {
 
             // Store outputs for each node
             const nodeOutputs = new Map<string, (Blob | WorkflowOutputFile)[]>();
+
+            const needsLibreOffice = executionOrder.some((nodeId) => {
+                const node = (nodes as WorkflowNode[]).find((n) => n.id === nodeId);
+                return node ? LIBREOFFICE_TOOL_IDS.has(node.data.toolId) : false;
+            });
+
+            if (needsLibreOffice && isCrossOriginIsolated()) {
+                logger.log('[Workflow] Preloading LibreOffice conversion engine...');
+                await preloadLibreOfficeConverter();
+            } else if (needsLibreOffice) {
+                logger.log(
+                    '[Workflow] Cross-Origin Isolation unavailable; Word .docx will use compatibility converter.'
+                );
+            }
 
             // Execute each node in order
             for (let i = 0; i < executionOrder.length; i++) {

--- a/src/lib/libreoffice/index.ts
+++ b/src/lib/libreoffice/index.ts
@@ -1,2 +1,7 @@
 export { LibreOfficeConverter, getLibreOfficeConverter } from './converter';
 export type { LoadProgress, ProgressCallback } from './converter';
+export {
+  getSharedLibreOfficeConverter,
+  preloadLibreOfficeConverter,
+  LIBREOFFICE_TOOL_IDS,
+} from './shared-converter';

--- a/src/lib/libreoffice/shared-converter.ts
+++ b/src/lib/libreoffice/shared-converter.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared LibreOffice converter loader for document-to-PDF processors.
+ * Resets the init promise on failure so retries (e.g. workflow nodes) can recover.
+ */
+
+import type { LibreOfficeConverter, ProgressCallback } from './converter';
+import { isCrossOriginIsolated } from '@/lib/utils/cross-origin-isolated';
+
+let converterPromise: Promise<LibreOfficeConverter> | null = null;
+let converterInstance: LibreOfficeConverter | null = null;
+
+export async function getSharedLibreOfficeConverter(
+  onProgress?: (percent: number, message: string) => void
+): Promise<LibreOfficeConverter> {
+  if (converterInstance?.isReady()) {
+    return converterInstance;
+  }
+
+  if (!converterPromise) {
+    converterPromise = (async () => {
+      const { getLibreOfficeConverter } = await import('./converter');
+      const instance = getLibreOfficeConverter();
+      await instance.initialize((progress) => {
+        onProgress?.(progress.percent, progress.message);
+      });
+      converterInstance = instance;
+      return instance;
+    })().catch((error) => {
+      converterPromise = null;
+      converterInstance = null;
+      throw error;
+    });
+  }
+
+  try {
+    return await converterPromise;
+  } catch (error) {
+    converterPromise = null;
+    converterInstance = null;
+    throw error;
+  }
+}
+
+/** Tool IDs that require LibreOffice WASM */
+export const LIBREOFFICE_TOOL_IDS = new Set([
+  'word-to-pdf',
+  'excel-to-pdf',
+  'pptx-to-pdf',
+  'ppt-to-pdf',
+  'rtf-to-pdf',
+]);
+
+export async function preloadLibreOfficeConverter(
+  onProgress?: ProgressCallback
+): Promise<void> {
+  if (!isCrossOriginIsolated()) {
+    return;
+  }
+  await getSharedLibreOfficeConverter((percent, message) => {
+    onProgress?.({ phase: 'loading', percent, message });
+  });
+}

--- a/src/lib/pdf/processors/excel-to-pdf.ts
+++ b/src/lib/pdf/processors/excel-to-pdf.ts
@@ -18,28 +18,7 @@ const MAX_FILE_SIZE = 50 * 1024 * 1024;
 /** Conversion timeout: 5 minutes */
 const CONVERT_TIMEOUT_MS = 5 * 60 * 1000;
 
-let converterPromise: Promise<any> | null = null;
-let converterInstance: any = null;
-
-async function getConverter(onProgress?: (percent: number, message: string) => void): Promise<any> {
-    if (converterInstance?.isReady()) return converterInstance;
-
-    if (converterPromise) {
-        await converterPromise;
-        return converterInstance;
-    }
-
-    converterPromise = (async () => {
-        const { getLibreOfficeConverter } = await import('@/lib/libreoffice');
-        converterInstance = getLibreOfficeConverter();
-        await converterInstance.initialize((progress: any) => {
-            onProgress?.(progress.percent, progress.message);
-        });
-    })();
-
-    await converterPromise;
-    return converterInstance;
-}
+import { getSharedLibreOfficeConverter } from '@/lib/libreoffice/shared-converter';
 export interface ExcelToPDFOptions {
     /** Reserved for future options */
 }
@@ -110,7 +89,7 @@ export class ExcelToPDFProcessor extends BasePDFProcessor {
         try {
             this.updateProgress(5, 'Loading conversion engine (first time may take 1-2 minutes)...');
 
-            const converter = await getConverter((percent, message) => {
+            const converter = await getSharedLibreOfficeConverter((percent, message) => {
                 this.updateProgress(Math.min(percent * 0.8, 80), message);
             });
 

--- a/src/lib/pdf/processors/pptx-to-pdf.ts
+++ b/src/lib/pdf/processors/pptx-to-pdf.ts
@@ -21,28 +21,7 @@ export interface PPTXToPDFOptions {
     /** Reserved for future options */
 }
 
-let converterPromise: Promise<any> | null = null;
-let converterInstance: any = null;
-
-async function getConverter(onProgress?: (percent: number, message: string) => void): Promise<any> {
-    if (converterInstance?.isReady()) return converterInstance;
-
-    if (converterPromise) {
-        await converterPromise;
-        return converterInstance;
-    }
-
-    converterPromise = (async () => {
-        const { getLibreOfficeConverter } = await import('@/lib/libreoffice');
-        converterInstance = getLibreOfficeConverter();
-        await converterInstance.initialize((progress: any) => {
-            onProgress?.(progress.percent, progress.message);
-        });
-    })();
-
-    await converterPromise;
-    return converterInstance;
-}
+import { getSharedLibreOfficeConverter } from '@/lib/libreoffice/shared-converter';
 
 export class PPTXToPDFProcessor extends BasePDFProcessor {
     private conversionProgressTimer: ReturnType<typeof setInterval> | null = null;
@@ -110,7 +89,7 @@ export class PPTXToPDFProcessor extends BasePDFProcessor {
         try {
             this.updateProgress(5, 'Loading conversion engine (first time may take 1-2 minutes)...');
 
-            const converter = await getConverter((percent, message) => {
+            const converter = await getSharedLibreOfficeConverter((percent, message) => {
                 this.updateProgress(Math.min(percent * 0.8, 80), message);
             });
 

--- a/src/lib/pdf/processors/rtf-to-pdf.ts
+++ b/src/lib/pdf/processors/rtf-to-pdf.ts
@@ -21,28 +21,7 @@ export interface RTFToPDFOptions {
     /** Reserved for future options */
 }
 
-let converterPromise: Promise<any> | null = null;
-let converterInstance: any = null;
-
-async function getConverter(onProgress?: (percent: number, message: string) => void): Promise<any> {
-    if (converterInstance?.isReady()) return converterInstance;
-
-    if (converterPromise) {
-        await converterPromise;
-        return converterInstance;
-    }
-
-    converterPromise = (async () => {
-        const { getLibreOfficeConverter } = await import('@/lib/libreoffice');
-        converterInstance = getLibreOfficeConverter();
-        await converterInstance.initialize((progress: any) => {
-            onProgress?.(progress.percent, progress.message);
-        });
-    })();
-
-    await converterPromise;
-    return converterInstance;
-}
+import { getSharedLibreOfficeConverter } from '@/lib/libreoffice/shared-converter';
 
 export class RTFToPDFProcessor extends BasePDFProcessor {
     private conversionProgressTimer: ReturnType<typeof setInterval> | null = null;
@@ -109,7 +88,7 @@ export class RTFToPDFProcessor extends BasePDFProcessor {
         try {
             this.updateProgress(5, 'Loading conversion engine (first time may take 1-2 minutes)...');
 
-            const converter = await getConverter((percent, message) => {
+            const converter = await getSharedLibreOfficeConverter((percent, message) => {
                 this.updateProgress(Math.min(percent * 0.8, 80), message);
             });
 

--- a/src/lib/pdf/processors/word-to-pdf-pyodide.ts
+++ b/src/lib/pdf/processors/word-to-pdf-pyodide.ts
@@ -1,0 +1,123 @@
+/**
+ * Word to PDF via Pyodide worker (python-docx + PyMuPDF).
+ * Used when Cross-Origin Isolation is unavailable (no SharedArrayBuffer / LibreOffice WASM).
+ * Supports .docx only.
+ */
+
+import { withBasePath } from '@/lib/utils/path';
+
+const WORKER_PATH = withBasePath('/workers/word-to-pdf.worker.js');
+const INIT_TIMEOUT_MS = 3 * 60 * 1000;
+const CONVERT_TIMEOUT_MS = 5 * 60 * 1000;
+
+let worker: Worker | null = null;
+let workerReady = false;
+let initPromise: Promise<void> | null = null;
+
+function getWorker(): Worker {
+  if (!worker) {
+    worker = new Worker(WORKER_PATH, { type: 'module' });
+  }
+  return worker;
+}
+
+async function ensureWorkerReady(
+  onStatus?: (message: string) => void
+): Promise<void> {
+  if (workerReady) return;
+
+  if (!initPromise) {
+    initPromise = new Promise<void>((resolve, reject) => {
+      const w = getWorker();
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error('Word converter worker initialization timed out.'));
+      }, INIT_TIMEOUT_MS);
+
+      const handleMessage = (event: MessageEvent) => {
+        const { type, error, message } = event.data;
+        if (type === 'status' && message) {
+          onStatus?.(message);
+        }
+        if (type === 'init-complete') {
+          workerReady = true;
+          cleanup();
+          resolve();
+        }
+        if (type === 'error') {
+          cleanup();
+          reject(new Error(error || 'Worker initialization failed'));
+        }
+      };
+
+      const handleError = () => {
+        cleanup();
+        reject(new Error('Word converter worker failed to load.'));
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        w.removeEventListener('message', handleMessage);
+        w.removeEventListener('error', handleError);
+      };
+
+      w.addEventListener('message', handleMessage);
+      w.addEventListener('error', handleError);
+      w.postMessage({ type: 'init', id: 'init', data: {} });
+    }).catch((err) => {
+      initPromise = null;
+      throw err;
+    });
+  }
+
+  await initPromise;
+}
+
+export async function convertWordToPdfPyodide(
+  file: File,
+  onStatus?: (message: string) => void
+): Promise<Blob> {
+  await ensureWorkerReady(onStatus);
+
+  return new Promise<Blob>((resolve, reject) => {
+    const w = getWorker();
+    const msgId = `convert-${Date.now()}`;
+
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('Word conversion timed out.'));
+    }, CONVERT_TIMEOUT_MS);
+
+    const handleMessage = (event: MessageEvent) => {
+      const { type, id, result, error, message } = event.data;
+      if (type === 'status' && message) {
+        onStatus?.(message);
+        return;
+      }
+      if (id !== msgId) return;
+
+      if (type === 'convert-complete') {
+        cleanup();
+        resolve(result);
+      } else if (type === 'error') {
+        cleanup();
+        reject(new Error(error || 'Conversion failed'));
+      }
+    };
+
+    const handleError = (err: ErrorEvent) => {
+      cleanup();
+      reject(new Error(err.message || 'Worker error'));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      w.removeEventListener('message', handleMessage);
+      w.removeEventListener('error', handleError);
+    };
+
+    w.addEventListener('message', handleMessage);
+    w.addEventListener('error', handleError);
+    w.postMessage({ type: 'convert', id: msgId, data: { file } });
+  });
+}

--- a/src/lib/pdf/processors/word-to-pdf.ts
+++ b/src/lib/pdf/processors/word-to-pdf.ts
@@ -1,7 +1,8 @@
 /**
  * Word to PDF Processor
- * 
- * Converts Word documents to PDF using LibreOffice WASM.
+ *
+ * Uses LibreOffice WASM when Cross-Origin Isolation is available (best fidelity).
+ * Falls back to Pyodide (python-docx) for .docx when isolation headers are missing.
  */
 
 import type {
@@ -11,6 +12,9 @@ import type {
 } from '@/types/pdf';
 import { PDFErrorCode } from '@/types/pdf';
 import { BasePDFProcessor } from '../processor';
+import { getSharedLibreOfficeConverter } from '@/lib/libreoffice/shared-converter';
+import { isCrossOriginIsolated } from '@/lib/utils/cross-origin-isolated';
+import { convertWordToPdfPyodide } from './word-to-pdf-pyodide';
 
 /** Maximum file size: 50 MB */
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
@@ -21,36 +25,11 @@ export interface WordToPDFOptions {
     /** Reserved for future options */
 }
 
-let converterPromise: Promise<any> | null = null;
-let converterInstance: any = null;
-
-async function getConverter(onProgress?: (percent: number, message: string) => void): Promise<any> {
-    if (converterInstance?.isReady()) return converterInstance;
-
-    if (converterPromise) {
-        await converterPromise;
-        return converterInstance;
-    }
-
-    converterPromise = (async () => {
-        const { getLibreOfficeConverter } = await import('@/lib/libreoffice');
-        converterInstance = getLibreOfficeConverter();
-        await converterInstance.initialize((progress: any) => {
-            onProgress?.(progress.percent, progress.message);
-        });
-    })();
-
-    await converterPromise;
-    return converterInstance;
-}
-
 export class WordToPDFProcessor extends BasePDFProcessor {
     private conversionProgressTimer: ReturnType<typeof setInterval> | null = null;
 
     private startConversionProgress(message: string): void {
         this.stopConversionProgress();
-        // LibreOffice convert() does not expose granular runtime progress.
-        // Keep UI responsive by advancing a bounded pseudo-progress while waiting.
         this.conversionProgressTimer = setInterval(() => {
             if (this.progress >= 98) return;
             this.updateProgress(this.progress + 1, message);
@@ -67,6 +46,51 @@ export class WordToPDFProcessor extends BasePDFProcessor {
     protected reset(): void {
         this.stopConversionProgress();
         super.reset();
+    }
+
+    private async convertWithLibreOffice(file: File): Promise<Blob> {
+        const converter = await getSharedLibreOfficeConverter((percent, message) => {
+            this.updateProgress(Math.min(percent * 0.8, 80), message);
+        });
+
+        if (this.checkCancelled()) {
+            throw new Error('Processing was cancelled.');
+        }
+
+        this.updateProgress(85, 'Converting Word document to PDF...');
+        this.startConversionProgress('Converting Word document to PDF...');
+
+        try {
+            return await Promise.race([
+                converter.convertToPdf(file),
+                new Promise<never>((_, reject) =>
+                    setTimeout(
+                        () =>
+                            reject(
+                                new Error(
+                                    `Conversion timed out after ${CONVERT_TIMEOUT_MS / 60000} minutes. The file may be too complex.`
+                                )
+                            ),
+                        CONVERT_TIMEOUT_MS
+                    )
+                ),
+            ]);
+        } finally {
+            this.stopConversionProgress();
+        }
+    }
+
+    private async convertWithPyodideFallback(file: File): Promise<Blob> {
+        this.updateProgress(
+            10,
+            'Using compatibility converter (server lacks Cross-Origin Isolation)...'
+        );
+
+        const pdfBlob = await convertWordToPdfPyodide(file, (message) => {
+            this.updateProgress(Math.min(this.progress + 2, 90), message);
+        });
+
+        return pdfBlob;
     }
 
     async process(
@@ -98,7 +122,6 @@ export class WordToPDFProcessor extends BasePDFProcessor {
             );
         }
 
-        // File size guard
         if (file.size > MAX_FILE_SIZE) {
             return this.createErrorOutput(
                 PDFErrorCode.INVALID_OPTIONS,
@@ -107,47 +130,49 @@ export class WordToPDFProcessor extends BasePDFProcessor {
             );
         }
 
+        const useLibreOffice = isCrossOriginIsolated();
+
+        if (!useLibreOffice && ext !== 'docx') {
+            return this.createErrorOutput(
+                PDFErrorCode.PROCESSING_FAILED,
+                `.${ext} files require LibreOffice, which needs Cross-Origin Isolation on your server.`,
+                'Your host must send Cross-Origin-Opener-Policy: same-origin and Cross-Origin-Embedder-Policy: require-corp on all HTML responses. Alternatively, convert the file to .docx first.'
+            );
+        }
+
         try {
-            this.updateProgress(5, 'Loading conversion engine (first time may take 1-2 minutes)...');
-
-            const converter = await getConverter((percent, message) => {
-                this.updateProgress(Math.min(percent * 0.8, 80), message);
-            });
+            const pdfBlob = useLibreOffice
+                ? await this.convertWithLibreOffice(file)
+                : await this.convertWithPyodideFallback(file);
 
             if (this.checkCancelled()) {
-                return this.createErrorOutput(PDFErrorCode.PROCESSING_CANCELLED, 'Processing was cancelled.');
-            }
-
-            this.updateProgress(85, 'Converting Word document to PDF...');
-            this.startConversionProgress('Converting Word document to PDF...');
-
-            // Convert with timeout protection
-            const pdfBlob = await Promise.race([
-                converter.convertToPdf(file),
-                new Promise<never>((_, reject) =>
-                    setTimeout(() => reject(new Error(
-                        `Conversion timed out after ${CONVERT_TIMEOUT_MS / 60000} minutes. The file may be too complex.`
-                    )), CONVERT_TIMEOUT_MS)
-                ),
-            ]);
-            this.stopConversionProgress();
-
-            if (this.checkCancelled()) {
-                return this.createErrorOutput(PDFErrorCode.PROCESSING_CANCELLED, 'Processing was cancelled.');
+                return this.createErrorOutput(
+                    PDFErrorCode.PROCESSING_CANCELLED,
+                    'Processing was cancelled.'
+                );
             }
 
             this.updateProgress(100, 'Conversion complete!');
 
             const baseName = file.name.replace(/\.(docx?|odt|rtf)$/i, '');
-            return this.createSuccessOutput(pdfBlob, `${baseName}.pdf`, { format: 'pdf' });
-
+            return this.createSuccessOutput(pdfBlob, `${baseName}.pdf`, {
+                format: 'pdf',
+                engine: useLibreOffice ? 'libreoffice' : 'pyodide',
+            });
         } catch (error) {
             this.stopConversionProgress();
             console.error('Conversion error:', error);
+            const details = error instanceof Error ? error.message : 'Unknown error';
+            const isEnvError = /SharedArrayBuffer|crossOriginIsolated|Cross-Origin/i.test(
+                details
+            );
+            const hint = isEnvError
+                ? 'Add COOP/COEP headers on your server, or use a .docx file (compatibility converter works without them).'
+                : 'Verify the file is a valid Word document and try again.';
             return this.createErrorOutput(
                 PDFErrorCode.PROCESSING_FAILED,
-                'Failed to convert Word document to PDF.',
-                error instanceof Error ? error.message : 'Unknown error'
+                `Failed to convert Word document to PDF: ${details}`,
+                `${details}\n\n${hint}`
             );
         }
     }

--- a/src/lib/utils/cross-origin-isolated.ts
+++ b/src/lib/utils/cross-origin-isolated.ts
@@ -1,0 +1,9 @@
+/**
+ * Detect whether the page can use SharedArrayBuffer (LibreOffice WASM, etc.).
+ */
+export function isCrossOriginIsolated(): boolean {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+  return window.crossOriginIsolated === true;
+}

--- a/src/lib/workflow/executor.ts
+++ b/src/lib/workflow/executor.ts
@@ -82,31 +82,67 @@ import { PDFToDocxProcessor } from '@/lib/pdf/processors/pdf-to-docx';
 import { PDFToPptxProcessor } from '@/lib/pdf/processors/pdf-to-pptx';
 import { PDFToExcelProcessor } from '@/lib/pdf/processors/pdf-to-excel';
 
+/** Default file extension when a workflow blob has no filename metadata */
+const TOOL_DEFAULT_EXTENSION: Record<string, string> = {
+    'word-to-pdf': 'docx',
+    'excel-to-pdf': 'xlsx',
+    'pptx-to-pdf': 'pptx',
+    'ppt-to-pdf': 'ppt',
+    'rtf-to-pdf': 'rtf',
+};
+
+function mimeTypeFromFilename(filename: string): string {
+    const lower = filename.toLowerCase();
+    if (lower.endsWith('.docx')) {
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    }
+    if (lower.endsWith('.doc')) return 'application/msword';
+    if (lower.endsWith('.odt')) return 'application/vnd.oasis.opendocument.text';
+    if (lower.endsWith('.rtf')) return 'application/rtf';
+    if (lower.endsWith('.xlsx')) {
+        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+    if (lower.endsWith('.xls')) return 'application/vnd.ms-excel';
+    if (lower.endsWith('.pptx')) {
+        return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    }
+    if (lower.endsWith('.ppt')) return 'application/vnd.ms-powerpoint';
+    if (lower.endsWith('.zip')) return 'application/zip';
+    if (lower.endsWith('.png')) return 'image/png';
+    if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+    if (lower.endsWith('.webp')) return 'image/webp';
+    if (lower.endsWith('.svg')) return 'image/svg+xml';
+    if (lower.endsWith('.txt')) return 'text/plain';
+    if (lower.endsWith('.json')) return 'application/json';
+    if (lower.endsWith('.pdf')) return 'application/pdf';
+    return 'application/octet-stream';
+}
+
+function defaultFilenameForTool(toolId: string, index: number, prefix: string): string {
+    const ext = TOOL_DEFAULT_EXTENSION[toolId] ?? 'pdf';
+    return `${prefix}_${index}.${ext}`;
+}
+
 /**
  * Convert WorkflowOutputFile or Blob to File with proper metadata
  */
-function convertToFile(input: File | Blob | WorkflowOutputFile, index: number, defaultName: string = 'input'): File {
+function convertToFile(
+    input: File | Blob | WorkflowOutputFile,
+    index: number,
+    defaultName: string = 'input',
+    toolId?: string
+): File {
     if (input instanceof File) return input;
-    
+
     if ('blob' in input && 'filename' in input) {
-        // WorkflowOutputFile with metadata
-        const filename = input.filename || `${defaultName}_${index}.pdf`;
-        let type = 'application/pdf';
-        
-        // Detect MIME type from extension
-        if (filename.endsWith('.zip')) type = 'application/zip';
-        else if (filename.endsWith('.png')) type = 'image/png';
-        else if (filename.endsWith('.jpg') || filename.endsWith('.jpeg')) type = 'image/jpeg';
-        else if (filename.endsWith('.webp')) type = 'image/webp';
-        else if (filename.endsWith('.svg')) type = 'image/svg+xml';
-        else if (filename.endsWith('.txt')) type = 'text/plain';
-        else if (filename.endsWith('.json')) type = 'application/json';
-        
+        const filename = input.filename || defaultFilenameForTool(toolId ?? '', index, defaultName);
+        const type = mimeTypeFromFilename(filename);
         return new File([input.blob], filename, { type });
     }
-    
-    // Plain Blob without metadata - TypeScript now knows input is Blob here
-    return new File([input as Blob], `${defaultName}_${index}.pdf`, { type: 'application/pdf' });
+
+    const filename = defaultFilenameForTool(toolId ?? '', index, defaultName);
+    const type = mimeTypeFromFilename(filename);
+    return new File([input as Blob], filename, { type });
 }
 
 /**
@@ -131,8 +167,8 @@ export async function executeNode(
     const settings = node.data.settings || {};
 
     // Convert all inputs to File objects with proper metadata
-    const files: File[] = inputFiles.map((f, i) => 
-        convertToFile(f, i, `workflow_${toolId}`)
+    const files: File[] = inputFiles.map((f, i) =>
+        convertToFile(f, i, `workflow_${toolId}`, toolId)
     );
 
     try {


### PR DESCRIPTION
Add Pyodide fallback for .docx when COOP/COEP headers are missing, shared LibreOffice loader with retry on init failure, workflow file MIME fixes, and LibreOffice preload only when isolation is enabled.